### PR TITLE
Fix El Tony Mate Zero glass store data

### DIFF
--- a/data/el_tony_mate_zero_glas.yml
+++ b/data/el_tony_mate_zero_glas.yml
@@ -43,25 +43,25 @@ stores:
         price: 26.40
         amount: 12
         date: 2026-04-02
-        comment: "12x EW"
+        comment: "EW"
     -
         name: "Pepillo"
         url: "https://www.pepillo.ch/kaufen/el-tony-mate-zero-24-x-33-cl-mw/"
         price: 52.80
         amount: 24
         date: 2026-04-02
-        comment: "24x MW (Mehrweg), Zürich Auslieferung"
+        comment: "MW (Mehrweg), Zürich Auslieferung"
     -
         name: "Paul Ullrich"
         url: "https://ullrich.ch/de/el-tony-mate-zero-ka-12x-ew-33cl/106628/"
         price: 2.20
         amount: 1
         date: 2026-04-02
-        comment: "12x EW"
+        comment: "EW"
     -
         name: "Paul Ullrich"
         url: "https://ullrich.ch/de/el-tony-mate-zero-ha-24x-mw-33cl/106629/"
         price: 2.30
         amount: 1
         date: 2026-04-02
-        comment: "24x MW (Mehrweg)"
+        comment: "MW (Mehrweg)"

--- a/data/el_tony_mate_zero_glas.yml
+++ b/data/el_tony_mate_zero_glas.yml
@@ -54,14 +54,14 @@ stores:
     -
         name: "Paul Ullrich"
         url: "https://ullrich.ch/de/el-tony-mate-zero-ka-12x-ew-33cl/106628/"
-        price: 2.20
-        amount: 1
+        price: 26.40
+        amount: 12
         date: 2026-04-02
         comment: "EW"
     -
         name: "Paul Ullrich"
         url: "https://ullrich.ch/de/el-tony-mate-zero-ha-24x-mw-33cl/106629/"
-        price: 2.30
-        amount: 1
+        price: 55.20
+        amount: 24
         date: 2026-04-02
         comment: "MW (Mehrweg)"


### PR DESCRIPTION
Fixes for the El Tony Mate Zero glass entry merged in #30:

- Remove redundant pack sizes from comments (e.g. '12 12x EW' → '12 EW')
- Fix Paul Ullrich prices to reflect pack totals (12x CHF 2.20 = CHF 26.40, 24x CHF 2.30 = CHF 55.20)