### PR TITLE
Add denner mate + fix build open file handle UTF8 char

### DIFF
--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ def render_products(env: jinja2.Environment, render_drafts: bool):
     product_filepaths = glob.glob(f"{DATA_DIR}/*.yml") + glob.glob(f"{DATA_DIR}/*.yaml")
 
     for product_filepath in product_filepaths:
-        with open(product_filepath) as product_raw:
+        with open(product_filepath, encoding="utf-8") as product_raw:
             product_yaml = yaml.safe_load(product_raw)
 
         if render_drafts is False and product_yaml.get("draft", False):
@@ -144,7 +144,7 @@ def render_products(env: jinja2.Environment, render_drafts: bool):
         product_yaml["filename"] = os.path.basename(product_filepath)
 
         # render product page brand_product_packaging.html
-        with open(f"{OUTPUT_DIR}/products/{site_url}", "w") as product_out:
+        with open(f"{OUTPUT_DIR}/products/{site_url}", "w", encoding="utf-8") as product_out:
             product_out.write(
                 product_template.render(
                     item=product_yaml,
@@ -164,7 +164,7 @@ def render_index(env: jinja2.Environment, products: Iterable[Dict]):
     print("[+] Rendering 'index.html'")
     main_template = env.get_template("main.jinja2")
 
-    with open(f"{OUTPUT_DIR}/index.html", "w") as main_out:
+    with open(f"{OUTPUT_DIR}/index.html", "w", encoding="utf-8") as main_out:
         main_out.write(
             main_template.render(
                 products=products,
@@ -180,7 +180,7 @@ def render_sitemap(env: jinja2.Environment, urls: Iterable[str]):
 
     print("[+] Rendering 'sitemap.xml'")
     sitemap_template = env.get_template("sitemap.jinja2")
-    with open(f"{OUTPUT_DIR}/sitemap.xml", "w") as sitemap_out:
+    with open(f"{OUTPUT_DIR}/sitemap.xml", "w", encoding="utf-8") as sitemap_out:
         sitemap_out.write(
             sitemap_template.render(
                 urls=sorted(urls),
@@ -201,7 +201,7 @@ def render_rss(env: jinja2.Environment, products: Iterable[Dict]):
         products, key=lambda product: product["newest_update"], reverse=True
     )
 
-    with open(f"{OUTPUT_DIR}/feed.xml", "w") as rss_out:
+    with open(f"{OUTPUT_DIR}/feed.xml", "w", encoding="utf-8") as rss_out:
         rss_out.write(
             rss_template.render(
                 products=sorted_products,

--- a/data/denner_mate.yml
+++ b/data/denner_mate.yml
@@ -1,0 +1,24 @@
+draft: false
+discontinued: false
+brand: Denner
+product: Mate
+size: 330
+packaging: Can
+caffeine: 23 
+sugar: 5.6 
+ingredients: 
+    - "Infusion de maté (91%) (Eau, maté)"
+    - "Sucre"
+    - "Jus de citron à base de concentré 3%"
+    - "Acide carbonique"
+    - "Extrait de guarana (0.2%)"
+    - "Acide citrique"
+    - "Arôme naturel"
+stores: # where to buy
+    -
+        name: Denner
+        url: https://www.denner.ch/fr/actions/denner-mate-canette~p1104100?variant=07be351a-92c1-44cd-93d4-425bc9af3fbc # direct product URL or URL to store (NO REFERRAL LINKS), ex. "https://somesite/products/mate.html"
+        price: 6 
+        amount: 6
+        date: 2026-04-26
+        comment: "-"


### PR DESCRIPTION
Product link

https://www.denner.ch/fr/actions/denner-mate-canette~p1104100?variant=07be351a-92c1-44cd-93d4-425bc9af3fbc

Pictures (sorry poor can quality xD)

<img width="4080" height="3072" alt="PXL_20260426_163936650" src="https://github.com/user-attachments/assets/23f9d88b-081b-4292-8d7f-5277e74e7c62" />
<img width="4080" height="3072" alt="PXL_20260426_163939958" src="https://github.com/user-attachments/assets/005e64db-77a1-4519-83db-67319f2d5c6b" />


Also, i had trouble building dev, i checked what happened with copilot and i fixed by specifying all utf8 char should be handled, i think this is specific to my laptop being on windows.

Copilot analysis : 

The build failed with a UnicodeEncodeError on Windows:

Root cause: All open() calls in build.py relied on Python's default encoding, which on Windows is cp1252 (Western European). The Jinja2 template product.jinja2 contains the ↗ character (U+2197, North East Arrow) used as a visual indicator on external links. When rendering product pages, Python tried to encode the rendered HTML using cp1252, which doesn't support this character.

Fix: Added explicit encoding="utf-8" to all 5 open() calls in build.py - both for reading YAML data files and writing rendered HTML/XML output. This ensures consistent UTF-8 handling regardless of the OS default encoding.